### PR TITLE
Update - 캐시 구매 API 기능 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import cashRouter from '../src/routes/cash.router.js';
 import errorHandlingMiddleware from './middlewares/error-handling.middleware.js';
 import config from './utils/configs.js';
 
@@ -10,7 +11,7 @@ app.get('/', (req, res) => {
 });
 
 app.use(express.json());
-//app.use('/api', []);
+app.use('/api', [cashRouter]);
 app.use(errorHandlingMiddleware);
 
 app.listen(PORT, () => {

--- a/src/routes/cash.router.js
+++ b/src/routes/cash.router.js
@@ -1,0 +1,37 @@
+import express from 'express';
+//import authMiddleware from '../middlewares/auth.middleware.js';
+import { prisma } from '../utils/prisma/index.js';
+
+const router = express.Router();
+
+// 캐시 구매 API (JWT 인증)
+/*
+  authMiddleware 인증 추가되면 파라미터에 넣어 반영 예정
+  ex) router.get('/cash', authMiddleware, async (req, res, next) => {});
+*/
+router.patch('/cash', async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+    await prisma.character.update({
+      where: {
+        UserId: userId,
+      },
+      data: {
+        cash: { increment: 1000 },
+      },
+    });
+    const changedCharacter = await prisma.character.findUnique({
+      where: {
+        UserId: userId,
+      },
+    });
+
+    return res.status(200).json({
+      message: '1000 캐시가 구매되었습니다.',
+      currentCash: changedCharacter.cash,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+export default router;

--- a/src/routes/cash.router.js
+++ b/src/routes/cash.router.js
@@ -1,15 +1,11 @@
 import express from 'express';
-//import authMiddleware from '../middlewares/auth.middleware.js';
+import authMiddleware from '../middlewares/auth.middleware.js';
 import { prisma } from '../utils/prisma/index.js';
 
 const router = express.Router();
 
 // 캐시 구매 API (JWT 인증)
-/*
-  authMiddleware 인증 추가되면 파라미터에 넣어 반영 예정
-  ex) router.get('/cash', authMiddleware, async (req, res, next) => {});
-*/
-router.patch('/cash', async (req, res, next) => {
+router.patch('/cash', authMiddleware, async (req, res, next) => {
   try {
     const { userId } = req.user;
     await prisma.character.update({

--- a/src/routes/character.router.js
+++ b/src/routes/character.router.js
@@ -4,7 +4,7 @@ import { prisma } from '../utils/prisma/index.js';
 
 const router = express.Router();
 
-// 풋살 온라인 캐릭터 정보 조회 API
+// 풋살 온라인 캐릭터 정보 조회 API (JWT 인증)
 router.get('/character/info', authMiddleware, async (req, res, next) => {
   try {
     const { userId } = req.user;


### PR DESCRIPTION
### 캐시 구매 API 기능 구현

- API 호출시 1000 캐시 획득
- authMiddleware 사용 JWT 인증

### API 테스트

- Request 없음
- HTTP Method : `PATCH`
- API URL : `/api/cash`

### 인섬니아

![image](https://github.com/eliotjang/futsal-online-project/assets/37320831/8d3f5ea4-5956-4a9a-bdd9-c3f6f59e49dd)
