### PR TITLE
7 update 보유 선수 목록 조회

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import RankingSystemRouter from '../src/routes/ranking-system.router.js';
 import DrawRouter from './routes/draw.router.js';
 import GameRouter from './routes/game.router.js';
 import RankGameRouter from './routes/rank-game.router.js';
+import PlayerRouter from './routes/player.router.js';
 import errorHandlingMiddleware from './middlewares/error-handling.middleware.js';
 import config from './utils/configs.js';
 import cookieParser from 'cookie-parser';
@@ -29,6 +30,7 @@ app.use('/api', [
   GameRouter,
   RankingSystemRouter,
   RankGameRouter,
+  PlayerRouter,
 ]);
 app.use(errorHandlingMiddleware);
 

--- a/src/routes/player.router.js
+++ b/src/routes/player.router.js
@@ -14,23 +14,30 @@ router.get('/players', authMiddleware, async (req, res, next) => {
         UserId: +userId,
       },
     });
-
+    
+    
     const characterPlayers = await prisma.characterPlayer.findMany({
-      where: {
-        CharacterId: character.characterId,
-      },
+        where: {
+            CharacterId: character.characterId,
+        },
     });
-
+    
     const characterPlayersData = [];
     for (const p of characterPlayers) {
         const player = await prisma.player.findFirst({
             where: {
                 playerId: p.playerId,
                 upgradeLevel: p.upgradeLevel,
-            }
+            },
         })
 
-        characterPlayersData.push(player);
+        const playerData = {
+            playerId: p.playerId,
+            playerName: player.playerName,
+            upgradeLevel: p.upgradeLevel,
+            playerCount: p.playerCount,
+        };
+        characterPlayersData.push(playerData);
     }
 
     return res.status(200).json({ message: '현재 캐릭터가 보유한 선수 목록입니다.', characterPlayersData});

--- a/src/routes/player.router.js
+++ b/src/routes/player.router.js
@@ -1,0 +1,42 @@
+import express from 'express';
+import { prisma } from '../utils/prisma/index.js';
+import authMiddleware from '../middlewares/auth.middleware.js';
+
+const router = express.Router();
+
+// 보유 선수 목록 조회 API
+router.get('/players', authMiddleware, async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    const character = await prisma.character.findFirst({
+      where: {
+        UserId: +userId,
+      },
+    });
+
+    const characterPlayers = await prisma.characterPlayer.findMany({
+      where: {
+        CharacterId: character.characterId,
+      },
+    });
+
+    const characterPlayersData = [];
+    for (const p of characterPlayers) {
+        const player = await prisma.player.findFirst({
+            where: {
+                playerId: p.playerId,
+                upgradeLevel: p.upgradeLevel,
+            }
+        })
+
+        characterPlayersData.push(player);
+    }
+
+    return res.status(200).json({ message: '현재 캐릭터가 보유한 선수 목록입니다.', characterPlayersData});
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
보유 선수 목록 조회 API 구현 완료

characterPlayer table에서 playerId, upgradeLevel, playerCount 사용,
player table에서 playerName 사용

선수 데이터들을 다 넣기엔 반환되는 데이터들이 너무 많아져서 지저분해 보일까봐 데이터들은 제외했습니다

API URL : `GET api/players`

![image](https://github.com/eliotjang/futsal-online-project/assets/166112137/a3aa7879-3d96-459d-a706-c0508f0f9d94)
