### PR TITLE
15 update 선수 강화 api 기능 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import RosterRouter from '../src/routes/roster.router.js';
 import RankingSystemRouter from '../src/routes/ranking-system.router.js';
 import DrawRouter from './routes/draw.router.js';
 import GameRouter from './routes/game.router.js';
+import UpgradeRouter from './routes/upgrade.router.js';
 import errorHandlingMiddleware from './middlewares/error-handling.middleware.js';
 import config from './utils/configs.js';
 import cookieParser from 'cookie-parser';
@@ -19,7 +20,16 @@ app.get('/', (req, res) => {
 
 app.use(express.json());
 app.use(cookieParser());
-app.use('/api', [UserRouter, CharacterRouter, CashRouter, RosterRouter, DrawRouter, GameRouter, RankingSystemRouter]);
+app.use('/api', [
+  UserRouter,
+  CharacterRouter,
+  CashRouter,
+  RosterRouter,
+  DrawRouter,
+  GameRouter,
+  RankingSystemRouter,
+  UpgradeRouter,
+]);
 app.use(errorHandlingMiddleware);
 
 app.listen(PORT, () => {

--- a/src/routes/upgrade.router.js
+++ b/src/routes/upgrade.router.js
@@ -1,0 +1,175 @@
+import express from 'express';
+import Joi from 'joi';
+import authMiddleware from '../middlewares/auth.middleware.js';
+import { prisma } from '../utils/prisma/index.js';
+import { Prisma } from '@prisma/client';
+
+const router = express.Router();
+
+// 강화 선수 유효성 검사
+const targetCharacterPlayerSchema = Joi.object({
+  characterPlayerId: Joi.number().integer().required(),
+});
+
+// 강화 재료 선수 유효성 검사
+const upgradeMaterialSchema = Joi.object({
+  upgradeMaterial: Joi.number().integer().required(),
+});
+
+// 강화 성공 시 true, 실패 시 false 반환
+function upgrade(targetUpgradeLevel, materialUpgradeLevel) {
+  const successProbability = [1, 0.8, 0.6, 0.4, 0.2];
+
+  if (targetUpgradeLevel < materialUpgradeLevel) return true;
+  else {
+    const probability =
+      successProbability[targetUpgradeLevel] * successProbability[targetUpgradeLevel - materialUpgradeLevel] * 100;
+
+    if (probability < Math.floor(Math.random() * 100)) return false;
+  }
+  return true;
+}
+
+// 보유 선수 명단 추가
+async function addCharacterPlayer(character, playerId, upgradeLevel, prisma) {
+  let newCharacterPlayer;
+
+  // 같은 선수를 보유 중인지 확인
+  const characterPlayer = character.CharacterPlayer.find((characterPlayer) => {
+    return characterPlayer.playerId === playerId && characterPlayer.upgradeLevel === upgradeLevel;
+  });
+
+  if (!characterPlayer) {
+    newCharacterPlayer = await prisma.characterPlayer.create({
+      data: {
+        CharacterId: character.characterId,
+        playerId,
+        upgradeLevel,
+        playerCount: 1,
+      },
+    });
+  } else {
+    newCharacterPlayer = await prisma.characterPlayer.update({
+      where: { characterPlayerId: characterPlayer.characterPlayerId },
+      data: { playerCount: { increment: 1 } },
+    });
+  }
+
+  return newCharacterPlayer;
+}
+
+// 선수 강화 API 기능 구현 (JWT 인증)
+router.post('/upgrade/:characterPlayerId', authMiddleware, async (req, res, next) => {
+  try {
+    // ##################################################################################
+    // authMiddleware에서 req.character로 캐릭터 객체를 넘겨주면 변경 필요
+    const { userId } = req.user;
+    const character = await prisma.character.findUnique({
+      where: { UserId: userId },
+      include: { CharacterPlayer: true },
+    });
+    // ##################################################################################
+
+    const paramsValidation = await targetCharacterPlayerSchema.validateAsync(req.params);
+    const { characterPlayerId: targetCharacterPlayerId } = paramsValidation;
+
+    const targetCharacterPlayer = character.CharacterPlayer.find((characterPlayer) => {
+      return characterPlayer.characterPlayerId === targetCharacterPlayerId;
+    });
+
+    if (!targetCharacterPlayer || targetCharacterPlayer.playerCount-- < 1) {
+      return res.status(400).json({ errorMessage: '강화할 선수가 현재 보유한 선수가 아닙니다.' });
+    }
+    if (targetCharacterPlayer.upgradeLevel > 4) {
+      return res.status(400).json({ errorMessage: '더 이상 강화할 수 없는 선수입니다.' });
+    }
+
+    const bodyValidaion = await upgradeMaterialSchema.validateAsync(req.body);
+    const { upgradeMaterial: materialCharacterPlayerId } = bodyValidaion;
+
+    const materialCharacterPlayer = character.CharacterPlayer.find((characterPlayer) => {
+      return characterPlayer.characterPlayerId === materialCharacterPlayerId;
+    });
+
+    if (!materialCharacterPlayer || materialCharacterPlayer.playerCount-- < 1) {
+      return res.status(400).json({ errorMessage: '강화 재료 선수가 현재 보유한 선수가 아닙니다.' });
+    }
+
+    if (targetCharacterPlayer.playerId !== materialCharacterPlayer.playerId) {
+      return res.status(400).json({ errorMessage: '강화 재료 선수는 강화할 선수와 동일 선수여야 합니다.' });
+    }
+
+    // 강화 성공 판정
+    const isSuccess = upgrade(targetCharacterPlayer.upgradeLevel, materialCharacterPlayer.upgradeLevel);
+
+    const upgradedCharacterPlayer = await prisma.$transaction(
+      async (tx) => {
+        // 강화된 선수 추가
+        let upgradedCharacterPlayer;
+
+        // 강화 성공 시
+        if (isSuccess) {
+          upgradedCharacterPlayer = await addCharacterPlayer(
+            character,
+            targetCharacterPlayer.playerId,
+            targetCharacterPlayer.upgradeLevel + 1,
+            tx
+          );
+        }
+        // 강화 실패 시
+        else {
+          upgradedCharacterPlayer = await addCharacterPlayer(character, targetCharacterPlayer.playerId, 0, tx);
+        }
+
+        // // 강화 선수 및 재료 소진
+        for (const characterPlayer of [targetCharacterPlayer, materialCharacterPlayer]) {
+          try {
+            const deletedCharacterPlayer = await tx.characterPlayer.delete({
+              where: { characterPlayerId: characterPlayer.characterPlayerId, playerCount: 1 },
+            });
+            if (!deletedCharacterPlayer) {
+              await tx.characterPlayer.update({
+                where: { characterPlayerId: characterPlayer.characterPlayerId },
+                data: { playerCount: { decrement: 1 } },
+              });
+            }
+          } catch {
+            await tx.characterPlayer.update({
+              where: { characterPlayerId: characterPlayer.characterPlayerId },
+              data: { playerCount: { decrement: 1 } },
+            });
+          }
+        }
+
+        return upgradedCharacterPlayer;
+      },
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+      }
+    );
+
+    return res.status(200).json({
+      message: isSuccess ? '강화에 성공하였습니다!!' : '강화에 실패하였습니다...',
+      baseData: await prisma.player.findUnique({
+        where: {
+          playerId_upgradeLevel: {
+            playerId: targetCharacterPlayer.playerId,
+            upgradeLevel: targetCharacterPlayer.upgradeLevel,
+          },
+        },
+      }),
+      changedData: await prisma.player.findUnique({
+        where: {
+          playerId_upgradeLevel: {
+            playerId: upgradedCharacterPlayer.playerId,
+            upgradeLevel: upgradedCharacterPlayer.upgradeLevel,
+          },
+        },
+      }),
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Update - 선수 강화 API 기능 구현
### API 주요 기능
- 보유한 선수를 강화하는 기능
- 강화 성공/실패 판정 기능
- 보유한 선수 중 같은 선수 2개를 조합하여 강화를 진행
  ※ 같은 선수 :  `player_id`가 동일한 선수를 말합니다.
- 강화된 선수는 보유 선수 목록에 추가됩니다.
- 강화하는 선수와 강화 재료로 사용되는 선수의 강화 단계(`upgrade_level`)에 따라 성공 확률이 달라집니다.

### API 테스트 순서
1. Path Parameters로 강화할 선수 추가 (`/:characterPlayerId`)
2. Request Body에서 선수 재료 추가 (`{ "upgradeMaterial" : "강화 재료로 사용할 보유 선수의 character_player_id" }`)
3. `POST /api/upgrade/:characterPlayerId`로 Request 발송
4. Response 확인
    - **강화 성공 시**
      강화 단계(`upgrade_level`)가 1 올라갑니다.
    ![image](https://github.com/eliotjang/futsal-online-project/assets/84895591/72e86b6f-bd86-4267-b782-efa8d911444b)

    - **강화 실패 시**
      강화 단계(`upgrade_level`)가 0이 됩니다.
    ![image](https://github.com/eliotjang/futsal-online-project/assets/84895591/843b4376-84b7-4918-8a64-a14ba90b11fe)

    - **강화 성공/실패 여부와 상관 없이 강화 재료로 사용된 선수는 사라집니다.**
      
### 선수 강화 로직
- 강화 성공/실패 여부를 `true/false`로 반환하는 함수 : `function upgrade(targetUpgradeLevel, materialUpgradeLevel)`
  - 강화 확률 표

||강화할 선수의 강화 단계(n)|
|---|---------------------------|
|강화 재료 선수의 강화 단계(m)| 강화 성공 확률(%)|

| | 0 | 1 | 2 | 3 | 4 | 
|---|---|---|---|---|---|
| 0|100 |64|36 |16 |4 |
| 1|100 |80 |48 |24 |8 |
| 2|100 |100 |60 |32|12 |
| 3|100 |100 |100 |40 |16 |
| 4|100 |100 |100 | 100|20 |

  - 기본 강화 성공 확률 : `upgrade_level`이 같은 선수들 간의 강화 성공 확률(n강 + n강 , 단위 : %)
    - 0강 + 0강 : 100
    - 1강 + 1강 : 80
    - 2강 + 2강 : 60
    - 3강 + 3강 : 40
    - 4강 + 4강 : 20
  - `upgrade_level`이 다른 선수들 간의 강화 성공 확률(n강 + m강, 단위 : %)
    - n < m 인 경우 : 100
    - n > m 인 경우 : n강 기본 강화 성공 확률 * (n-m)강 기본 강화 성공 확률
      > n=2, m=0 일 때, 강화 성공 확률 : 60 * 60 = 36
         n=2, m=1 일 때, 강화 성공 확률 : 60 * 80 = 48
         n=4, m=1 일 때, 강화 성공 확률 : 20 * 40 = 8

- 강화할 선수 및 강화 재료 선수가 보유 선수 명단에 존재하는 지 확인
```
character.CharacterPlayer.find((characterPlayer) => {
      return characterPlayer.characterPlayerId === (강화할 선수의 or 강화 재료 선수의 CharacterPlayerId) ;
    });

    if (!(강화할 선수의 or 강화 재료 선수) || (강화할 선수의 or 강화 재료 선수의 playerCount)-- < 1) {
      return res.status(400).json({ errorMessage: '강화할 선수가 현재 보유한 선수가 아닙니다.' });
    }
```
- 강화 최대 단계(5강) 이상 강화 진행 불가
```
    if (targetCharacterPlayer.upgradeLevel > 4) {
      return res.status(400).json({ errorMessage: '더 이상 강화할 수 없는 선수입니다.' });
    }
```
- 강화할 선수와 강화 재료 선수가 동일 선수여야만 강화 진행 가능
```
    if (targetCharacterPlayer.playerId !== materialCharacterPlayer.playerId) {
      return res.status(400).json({ errorMessage: '강화 재료 선수는 강화할 선수와 동일 선수여야 합니다.' });
    }
```
- 강화 성공 판정
`const isSuccess = upgrade(targetCharacterPlayer.upgradeLevel, materialCharacterPlayer.upgradeLevel);`

- 강화 성공 시 보유 선수 명단에 동일 선수의 동일 강화 단계인 선수가 있는 지 확인하고 update, 없다면 create 진행
```
if (isSuccess) {
          upgradedCharacterPlayer = await addCharacterPlayer(
            character,
            targetCharacterPlayer.playerId,
            targetCharacterPlayer.upgradeLevel + 1,
            tx
          );
        }

// 보유 선수 명단에 동일 선수의 동일 강화 단계인 선수가 있는 지 확인하고 update, 없다면 create 진행하는 함수
async function addCharacterPlayer(character, playerId, upgradeLevel, prisma){
  let newCharacterPlayer;

  // 동일 선수의 동일 강화 단계인 선수를 보유 중인지 확인
  const characterPlayer = character.CharacterPlayer.find((characterPlayer) => {
    return characterPlayer.playerId === playerId && characterPlayer.upgradeLevel === upgradeLevel;
  });

  // 동일 선수의 동일 강화 단계인 선수 미보유
  if (!characterPlayer) {
    newCharacterPlayer = await prisma.characterPlayer.create({ });
  } else {  // 동일 선수의 동일 강화 단계인 선수 보유
    newCharacterPlayer = await prisma.characterPlayer.update({ });
  }

  return newCharacterPlayer;
}
```

- 강화에 사용된 선수 (강화 선수, 강화 재료 선수) 차감
  - 출전 선수 명단에 포함된 선수 강화 불가
  - 동일한 선수가 보유 선수 명단에 있는 경우 (`player_count>0`) 보유 선수 명단에 있는 해당 선수는 강화 가능
```
for (const characterPlayer of [targetCharacterPlayer, materialCharacterPlayer]) {
          try {
           // 강화할 선수 or 강화 재료 선수의 playerCount가 1이였다면 delete
           // 출전 선수 명단에 포함된 선수와 동일한 character_player_id를 가진 보유 선수를 강화에 사용하여 playerCount가 0이 되는 경우 onDelete:Restrict 설정에 의한 오류 발생하여 catch문으로
            const deletedCharacterPlayer = await tx.characterPlayer.delete({
              where: { characterPlayerId: characterPlayer.characterPlayerId, playerCount: 1 },
            });
           // playerCount가 1이 아니라면 1 감소
            if (!deletedCharacterPlayer) {
              await tx.characterPlayer.update({
                where: { characterPlayerId: characterPlayer.characterPlayerId },
                data: { playerCount: { decrement: 1 } },
              });
            }
          } catch { // 출전 선수 명단에 포함된 선수와 동일한 character_player_id를 가진 보유 선수를 강화에 사용하여 playerCount가 0이 되는 경우 delete하지 않음
            await tx.characterPlayer.update({
              where: { characterPlayerId: characterPlayer.characterPlayerId },
              data: { playerCount: { decrement: 1 } },
            });
          }
        }
```
- 강화 실패 시, 강화 성공 시 `addCharacterPlayer()` 함수의 parameter를 변경, 이후 동일
`upgradedCharacterPlayer = await addCharacterPlayer(character, targetCharacterPlayer.playerId, 0, tx);`


### 기타 사항
- http method 변경 : `PUT` -> `POST`
  - 변경된 API URL : `POST /api/upgrade/:characterPlayerId`
  - 강화를 진행하는 보유 선수의 `player_count`가 3 이상인 경우 강화를 성공했을 시 해당 row의 `upgrade_level`만 변경하면 강화 선수와 그 재료를 제외한 n-2 (n은 3 이상) 개의 선수도 같이 강화될 수 있음
  - 강화 성공 시 강화 선수를 `create` 해야하는 경우가 있기 때문에 `POST`로 변경
  
### 수정 또는 추가된 파일 목록
update - "src/app.js"
- import 선수 강화 api

add - "src/routes/upgrade.router.js"
- 선수 강화 api 기능 구현
