### PR TITLE
update-희귀도에 따른 선수 뽑기 API 기능 구현 완료

### DIFF
--- a/src/routes/draw.router.js
+++ b/src/routes/draw.router.js
@@ -20,10 +20,35 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
       return res.status(400).json({ Message: '보유 캐쉬가 부족합니다.' });
     }
 
+    const tier0 = 0.05; //티어에 따른 확률 
+    const tier1 = 0.1;
+    const tier2 = 0.15;
+    const tier3 = 0.2;
+    const tier4 = 0.2;
+    const tier5 = 0.3;
+
+    let rarity = 0;
+
+    const randomNumRarity = Math.random(); //희귀 등급 뽑기
+    if(randomNumRarity < tier0){
+      rarity = 0;
+    }else if(randomNumRarity < tier0 + tier1){
+      rarity = 1;
+    }else if(randomNumRarity < tier0 + tier1 + tier2 ){
+      rarity = 2;
+    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 ){
+      rarity = 3;
+    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4){
+      rarity = 4;
+    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4 + tier5){
+      rarity = 5;
+    }
+
     const playerList = await prisma.player.findMany({
       //뽑기 선수 리스트 조회
       where: {
-        upgradeLevel: 0,
+        rarity: rarity,
+        upgradeLevel: 0
       },
     });
 


### PR DESCRIPTION
## update-희귀도에 따른 선수 뽑기 API 기능 구현

### 기존 뽑기 로직에서 희귀도에 따른 뽑기확률 변동을 구현

1.  티어에 따른 확률 수치를 정함
2. 랜덤으로 숫자를 돌린 뒤에 확률 수치에 따른 뽑을 선수 티어를 정함 
3. 뽑힌 티어와 같은 선수 목록만 조회함
4. 그중에서 같은 확률로 랜덤으로 선수를 뽑는다.

### 인섬니아
![image](https://github.com/eliotjang/futsal-online-project/assets/112794665/e1b0a269-ee51-4b6c-ae50-b0195b880f25)
