### PR TITLE
16 update 선수 방출 api 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,10 +18,11 @@ model User {
 }
 
 model Character {
-  characterId Int    @id @default(autoincrement()) @map("character_id")
-  UserId      Int    @unique @map("user_id")
-  name        String @unique @map("name")
-  cash        Int    @default(10000) @map("cash")
+  characterId  Int    @id @default(autoincrement()) @map("character_id")
+  UserId       Int    @unique @map("user_id")
+  name         String @unique @map("name")
+  cash         Int    @default(10000) @map("cash")
+  releaseCount Int    @default(0) @map("release_count")
 
   CharacterPlayer CharacterPlayer[]
   Roster          Roster?

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import RankingSystemRouter from '../src/routes/ranking-system.router.js';
 import DrawRouter from './routes/draw.router.js';
 import GameRouter from './routes/game.router.js';
 import RankGameRouter from './routes/rank-game.router.js';
+import CharacterPlayerRelease from './routes/character-player-release.js';
 import errorHandlingMiddleware from './middlewares/error-handling.middleware.js';
 import config from './utils/configs.js';
 import cookieParser from 'cookie-parser';
@@ -29,6 +30,7 @@ app.use('/api', [
   GameRouter,
   RankingSystemRouter,
   RankGameRouter,
+  CharacterPlayerRelease,
 ]);
 app.use(errorHandlingMiddleware);
 

--- a/src/routes/character-player-release.js
+++ b/src/routes/character-player-release.js
@@ -1,0 +1,80 @@
+import express from 'express';
+import authMiddleware from '../middlewares/auth.middleware.js';
+import { prisma } from '../utils/prisma/index.js';
+
+const router = express.Router();
+
+router.delete('/players/:characterPlayerId', authMiddleware, async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+    const { characterPlayerId } = req.params;
+    const character = await prisma.character.findUnique({
+      where: { UserId: userId },
+    });
+    const characterPlayers = await prisma.characterPlayer.findMany({
+      where: { CharacterId: character.characterId },
+      select: { characterPlayerId: true, playerCount: true },
+    });
+    const characterPlayer = await prisma.characterPlayer.findUnique({
+      where: { characterPlayerId: +characterPlayerId },
+    });
+    if (!characterPlayer) {
+      return res.status(400).json({ errorMessage: '해당 선수를 보유하고 있지 않습니다.' });
+    }
+    if (characterPlayer.playerCount === 0) {
+      return res.status(400).json({ errorMessage: '출전 선수 명단에 있는 선수입니다.' });
+    }
+
+    // 선수 방출
+    if (characterPlayer.playerCount === 1) {
+      await prisma.characterPlayer.delete({
+        where: { characterPlayerId: +characterPlayerId },
+      });
+    } else {
+      await prisma.characterPlayer.update({
+        where: { characterPlayerId: +characterPlayerId },
+        data: {
+          playerCount: { decrement: 1 },
+        },
+      });
+    }
+
+    // 선수 방출 패널티 부여
+    await prisma.character.update({
+      where: { UserId: userId },
+      data: {
+        releaseCount: { increment: 1 },
+      },
+    });
+
+    // 방출 금액 정산
+    const playerId = characterPlayer.playerId;
+    const upgradeLevel = characterPlayer.upgradeLevel;
+    const player = await prisma.player.findUnique({
+      where: {
+        playerId_upgradeLevel: { playerId, upgradeLevel },
+      },
+    });
+    await prisma.character.update({
+      where: { UserId: userId },
+      data: {
+        cash: { increment: player.value },
+      },
+    });
+
+    // 변경 금액 확인
+    const currentCash = await prisma.character.findUnique({
+      where: { UserId: userId },
+      select: { cash: true },
+    });
+
+    return res.status(200).json({
+      message: `${player.playerName} 선수(${player.upgradeLevel}강)를 방출했습니다.`,
+      currentCash: currentCash,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/routes/character.router.js
+++ b/src/routes/character.router.js
@@ -16,6 +16,7 @@ router.get('/character/info', authMiddleware, async (req, res, next) => {
         characterId: true,
         name: true,
         cash: true,
+        releaseCount: true,
       },
     });
 

--- a/src/routes/draw.router.js
+++ b/src/routes/draw.router.js
@@ -28,7 +28,7 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
       return res.status(400).json({ Message: '보유 캐쉬가 부족합니다.' });
     }
 
-    const tier0 = 0.05; //티어에 따른 확률 
+    const tier0 = 0.05; //티어에 따른 확률
     const tier1 = 0.1;
     const tier2 = 0.15;
     const tier3 = 0.2;
@@ -38,17 +38,17 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
     let rarity = 0;
 
     const randomNumRarity = Math.random(); //희귀 등급 뽑기
-    if(randomNumRarity < tier0){
+    if (randomNumRarity < tier0) {
       rarity = 0;
-    }else if(randomNumRarity < tier0 + tier1){
+    } else if (randomNumRarity < tier0 + tier1) {
       rarity = 1;
-    }else if(randomNumRarity < tier0 + tier1 + tier2 ){
+    } else if (randomNumRarity < tier0 + tier1 + tier2) {
       rarity = 2;
-    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 ){
+    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3) {
       rarity = 3;
-    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4){
+    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4) {
       rarity = 4;
-    }else if(randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4 + tier5){
+    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4 + tier5) {
       rarity = 5;
     }
 
@@ -56,7 +56,7 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
       //뽑기 선수 리스트 조회
       where: {
         rarity: rarity,
-        upgradeLevel: 0
+        upgradeLevel: 0,
       },
     });
 


### PR DESCRIPTION
### Update - 선수 방출 API 기능 구현

- 선수 방출 시 캐릭터 패널티 부여
    - 선수 방출 횟수 카운트
    - 선수 뽑기 시 1000 캐시 추가 소요
        - 이후 선수 방출 횟수 차감
- 선수 가치에 따른 판매
    - 가치 : 1000 캐시 x (강화 단계 +1)
- API URL : `DELETE /api/players/:character_player_id`

### API 테스트

- Path Parameters : 보유 선수의 characterPlayerId
- HTTP Method : `DELETE`
- API URL : `/api/players/:character_player_id`

### 인섬니아 - 선수 방출 API

![image](https://github.com/eliotjang/futsal-online-project/assets/37320831/6b474ae3-f4b2-42c8-b26a-39529613dce2)


### 인섬니아 - 선수 방출 횟수에 따른 선수 뽑기 Response 변경 내용

![image](https://github.com/eliotjang/futsal-online-project/assets/37320831/ae1ebf6c-bd76-43de-9d40-2c9815dcc501)
