### PR TITLE
bugfix - 출전 선수 명단 구성 중복 선수 허용 오류 수정

### DIFF
--- a/src/routes/roster.router.js
+++ b/src/routes/roster.router.js
@@ -34,6 +34,7 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
     });
     // ##################################################################################
     const characterPlayerIds = [characterPlayerId1, characterPlayerId2, characterPlayerId3];
+    const playerIds = [];
     for (const characterPlayerId of characterPlayerIds) {
       const characterPlayer = character.CharacterPlayer.find((characterPlayer) => {
         return characterPlayer.characterPlayerId === characterPlayerId;
@@ -42,6 +43,11 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
       if (!characterPlayer) {
         return res.status(400).json({ errorMessage: '선수 아이디가 유효하지 않습니다.' });
       }
+      playerIds.push(characterPlayer.playerId);
+    }
+
+    if (playerIds[0] === playerIds[1] || playerIds[0] === playerIds[2] || playerIds[1] === playerIds[2]) {
+      return res.status(400).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
     }
 
     // 출전 선수 명단 생성


### PR DESCRIPTION
## Bugfix - 출전 선수 명단 구성 중복 선수 허용 오류
### 발생한 문제
- 팀에 선수 아이디가 같은 선수가 허용되는 문제
![image](https://github.com/eliotjang/futsal-online-project/assets/84895591/0b597c6d-6681-43c9-bf3b-bd304db443dd)

### 원인
1. Request로 받는 `character_player_id1~3`의 중복성만 검사하고 해당 보유 선수의 실제 선수 아이디인 `player_id1~3`을 중복 검사하지 않아 생기는 문제

### 해결법
1. 실제 선수 아이디인 `player_id1~3`에 대한 중복 검사 코드 추가
```
 if (playerIds[0] === playerIds[1] || playerIds[0] === playerIds[2] || playerIds[1] === playerIds[2]) {
      return res.status(400).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
    }
```

### 이슈 해결 후 동작 확인
![image](https://github.com/eliotjang/futsal-online-project/assets/84895591/11119810-b431-47ed-859d-713c2e09a966)

### 수정 파일
- bugfix - `roster.router.js`