### PR TITLE
52 update 선수 트레이딩 api 기능 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,8 +8,9 @@ import DrawRouter from './routes/draw.router.js';
 import GameRouter from './routes/game.router.js';
 import UpgradeRouter from './routes/upgrade.router.js';
 import RankGameRouter from './routes/rank-game.router.js';
-import CharacterPlayerRelease from './routes/character-player-release.js';
+import CharacterPlayerReleaseRouter from './routes/character-player-release.js';
 import PlayerRouter from './routes/player.router.js';
+import PlayerTradingRouter from './routes/player-trading.router.js';
 import errorHandlingMiddleware from './middlewares/error-handling.middleware.js';
 import config from './utils/configs.js';
 import cookieParser from 'cookie-parser';
@@ -33,8 +34,9 @@ app.use('/api', [
   RankingSystemRouter,
   UpgradeRouter,
   RankGameRouter,
-  CharacterPlayerRelease,
+  CharacterPlayerReleaseRouter,
   PlayerRouter,
+  PlayerTradingRouter,
 ]);
 app.use(errorHandlingMiddleware);
 

--- a/src/routes/character-player-release.js
+++ b/src/routes/character-player-release.js
@@ -4,6 +4,7 @@ import { prisma } from '../utils/prisma/index.js';
 
 const router = express.Router();
 
+// 보유 선수 방출 API (JWT 인증)
 router.delete('/players/:characterPlayerId', authMiddleware, async (req, res, next) => {
   try {
     const { characterId } = req.character;

--- a/src/routes/draw.router.js
+++ b/src/routes/draw.router.js
@@ -5,8 +5,8 @@ import { Prisma } from '@prisma/client';
 
 const router = express.Router();
 
+// 선수 뽑기 API (JWT 인증)
 router.post('/draw', authMiddleware, async (req, res, next) => {
-  // 선수 뽑기 API
   try {
     const { characterId } = req.character;
 

--- a/src/routes/game.router.js
+++ b/src/routes/game.router.js
@@ -4,8 +4,8 @@ import { prisma } from '../utils/prisma/index.js';
 
 const router = express.Router();
 
+// 일반(상대지정) 풋살 게임 API
 router.post('/games/play/:characterId', authMiddleware, async (req, res, next) => {
-  // 일반(상대지정) 풋살 게임
   try {
     const { characterId } = req.params;
 
@@ -71,7 +71,7 @@ router.post('/games/play/:characterId', authMiddleware, async (req, res, next) =
         await prisma.player.findFirst({
           where: {
             playerId: element.rosterPlayerId,
-            upgradeLevel: element.rosterUpgradeLevel
+            upgradeLevel: element.rosterUpgradeLevel,
           },
         })
       );
@@ -83,7 +83,7 @@ router.post('/games/play/:characterId', authMiddleware, async (req, res, next) =
         await prisma.player.findFirst({
           where: {
             playerId: element.rosterPlayerId,
-            upgradeLevel: element.rosterUpgradeLevel
+            upgradeLevel: element.rosterUpgradeLevel,
           },
         })
       );
@@ -134,7 +134,7 @@ router.post('/games/play/:characterId', authMiddleware, async (req, res, next) =
         gameLog.push({
           gameTime: `${currentTime}분`,
           goalTeam: `${teamACharacter.name} 팀`,
-          goalPlayer : teamAPlayerInfo[addScorePlayer].playerName
+          goalPlayer: teamAPlayerInfo[addScorePlayer].playerName,
         });
       } else {
         //B팀이 이길 경우
@@ -142,7 +142,7 @@ router.post('/games/play/:characterId', authMiddleware, async (req, res, next) =
         gameLog.push({
           gameTime: `${currentTime}분`,
           goalTeam: `${teamBCharacter.name} 팀`,
-          goalPlayer : teamBPlayerInfo[addScorePlayer].playerName
+          goalPlayer: teamBPlayerInfo[addScorePlayer].playerName,
         });
       }
       currentTime += Math.floor(Math.random() * 45); //경기가 지난 시간 랜덤으로 결정

--- a/src/routes/player-trading.router.js
+++ b/src/routes/player-trading.router.js
@@ -49,6 +49,9 @@ router.patch('/trading/:characterPlayerId', authMiddleware, async (req, res, nex
     }
 
     // 0. 트레이드 금액 제안 확인
+    if (myCharacter.cash < offerCash) {
+      return res.status(400).json({ errorMessage: '보유 캐시가 부족합니다.' });
+    }
     let compareValuePrice = 0;
     if (myPlayer.value >= targetPlayer.value) {
       compareValuePrice = offerCash;

--- a/src/routes/player-trading.router.js
+++ b/src/routes/player-trading.router.js
@@ -1,0 +1,233 @@
+import express from 'express';
+import authMiddleware from '../middlewares/auth.middleware.js';
+import { prisma } from '../utils/prisma/index.js';
+import Joi from 'joi';
+
+const router = express.Router();
+
+const tradeSchema = Joi.object({
+  tradeCharacterId: Joi.number().integer().min(0).required(),
+  tradeCharacterPlayerId: Joi.number().integer().min(0).required(),
+  offerCash: Joi.number().integer().min(0).required(),
+});
+
+// 선수 트레이딩 API (JWT 인증)
+router.patch('/trading/:characterPlayerId', authMiddleware, async (req, res, next) => {
+  try {
+    const { characterId } = req.character;
+    const { characterPlayerId } = req.params;
+    const { tradeCharacterId, tradeCharacterPlayerId, offerCash } = await tradeSchema.validateAsync(req.body);
+
+    // 사용자 및 상대 캐릭터
+    const myCharacter = await prisma.character.findUnique({ where: { characterId } });
+    const targetCharacter = await prisma.character.findUnique({ where: { characterId: tradeCharacterId } });
+
+    // 사용자 및 상대 캐릭터 보유 선수
+    const myCharacterPlayer = await prisma.characterPlayer.findUnique({
+      where: { characterPlayerId: +characterPlayerId },
+    });
+    const targetCharacterPlayer = await prisma.characterPlayer.findUnique({
+      where: { characterPlayerId: tradeCharacterPlayerId },
+    });
+
+    // 사용자 및 상대 트레이드 선수
+    const myPlayer = await prisma.player.findFirst({
+      where: { playerId: myCharacterPlayer.playerId, upgradeLevel: myCharacterPlayer.upgradeLevel },
+    });
+    const targetPlayer = await prisma.player.findFirst({
+      where: { playerId: targetCharacterPlayer.playerId, upgradeLevel: targetCharacterPlayer.upgradeLevel },
+    });
+
+    if (!myCharacter || !targetCharacter) {
+      return res.status(400).json({ errorMessage: '유효하지 않은 캐릭터입니다.' });
+    }
+    if (!myCharacterPlayer || !targetCharacterPlayer) {
+      return res.status(400).json({ errorMessage: '유효하지 않은 보유 선수입니다.' });
+    }
+    if (myCharacterPlayer.playerCount === 0 || tradeCharacterPlayerId.playerCount === 0) {
+      return res.status(400).json({ errorMessage: '유효하지 않은 보유 선수의 개수입니다.' });
+    }
+
+    // 0. 트레이드 금액 제안 확인
+    let compareValuePrice = 0;
+    if (myPlayer.value >= targetPlayer.value) {
+      compareValuePrice = offerCash;
+    }
+    // myPlayer.value < targetPlayer.value
+    else {
+      if (myPlayer.value + offerCash > targetPlayer.value) {
+        compareValuePrice = offerCash;
+      } else {
+        return res.status(200).json({ message: `${targetCharacter.name}님께서 트레이드 제안을 거절했습니다.` });
+      }
+    }
+
+    // 1. 사용자 선수를 상대 보유 선수 이동
+    // 사용자 보유 선수 차감
+    if (myCharacterPlayer.playerCount === 1) {
+      await prisma.characterPlayer.delete({
+        where: { characterPlayerId: +characterPlayerId },
+      });
+    } else {
+      await prisma.characterPlayer.update({
+        where: { characterPlayerId: +characterPlayerId },
+        data: { playerCount: { decrement: 1 } },
+      });
+    }
+    // 상대 보유 선수 테이블에서 사용자 보유 선수 확인
+    const myCharacterPlayerTrade = await prisma.characterPlayer.findFirst({
+      where: {
+        CharacterId: tradeCharacterId,
+        playerId: myCharacterPlayer.playerId,
+        upgradeLevel: myCharacterPlayer.upgradeLevel,
+      },
+    });
+    // 상대 보유 선수 테이블에 사용자 보유 선수 생성 or 개수 증가
+    if (!myCharacterPlayerTrade) {
+      const newMyCharacterPlayerTrade = await prisma.characterPlayer.create({
+        data: {
+          CharacterId: tradeCharacterId,
+          playerId: myCharacterPlayer.playerId,
+          upgradeLevel: myCharacterPlayer.upgradeLevel,
+          playerCount: 1,
+        },
+      });
+    } else {
+      await prisma.characterPlayer.update({
+        where: {
+          characterPlayerId: myCharacterPlayerTrade.characterPlayerId,
+        },
+        data: {
+          playerCount: { increment: 1 },
+        },
+      });
+    }
+
+    // 2. 사용자 선수를 상대 보유 선수 이동
+    // 상대 보유 선수 차감
+    if (targetCharacterPlayer.playerCount === 1) {
+      await prisma.characterPlayer.delete({
+        where: { characterPlayerId: tradeCharacterPlayerId },
+      });
+    } else {
+      await prisma.characterPlayer.update({
+        where: { characterPlayerId: tradeCharacterPlayerId },
+        data: { playerCount: { decrement: 1 } },
+      });
+    }
+    // 사용자 보유 선수 테이블에서 상대 보유 선수 확인
+    const targetCharacterPlayerTrade = await prisma.characterPlayer.findFirst({
+      where: {
+        CharacterId: characterId,
+        playerId: targetCharacterPlayer.playerId,
+        upgradeLevel: targetCharacterPlayer.upgradeLevel,
+      },
+    });
+    // 사용자 보유 선수 테이블에 상대 보유 선수 생성 or 개수 증가
+    if (!targetCharacterPlayerTrade) {
+      const newTargetCharacterPlayerTrade = await prisma.characterPlayer.create({
+        data: {
+          CharacterId: characterId,
+          playerId: targetCharacterPlayer.playerId,
+          upgradeLevel: targetCharacterPlayer.upgradeLevel,
+          playerCount: 1,
+        },
+      });
+    } else {
+      await prisma.characterPlayer.update({
+        where: {
+          characterPlayerId: targetCharacterPlayerTrade.characterPlayerId,
+        },
+        data: {
+          playerCount: { increment: 1 },
+        },
+      });
+    }
+
+    // 3. 트레이드 선수 확인
+
+    // 사용자 보유 선수에서 상대로 트레이드 완료된 선수 확인
+    const tradedMyPlayer = await prisma.characterPlayer.findFirst({
+      where: {
+        CharacterId: tradeCharacterId,
+        playerId: myCharacterPlayer.playerId,
+        upgradeLevel: myCharacterPlayer.upgradeLevel,
+      },
+      select: {
+        characterPlayerId: true,
+        CharacterId: true,
+        playerId: true,
+        upgradeLevel: true,
+      },
+    });
+    // 상대 보유 선수에서 사용자로 트레이드 완료된 선수 확인
+    const tradedTargetPlayer = await prisma.characterPlayer.findFirst({
+      where: {
+        CharacterId: characterId,
+        playerId: targetCharacterPlayer.playerId,
+        upgradeLevel: targetCharacterPlayer.upgradeLevel,
+      },
+      select: {
+        characterPlayerId: true,
+        CharacterId: true,
+        playerId: true,
+        upgradeLevel: true,
+      },
+    });
+
+    // 4. 선수 트레이드 비용 전달
+    await prisma.character.update({
+      where: { characterId: myCharacter.characterId },
+      data: {
+        cash: { decrement: compareValuePrice },
+      },
+    });
+    await prisma.character.update({
+      where: { characterId: targetCharacter.characterId },
+      data: {
+        cash: { increment: compareValuePrice },
+      },
+    });
+
+    return res.status(200).json({
+      message: `${myPlayer.playerName} 선수와 ${targetPlayer.playerName} 선수의 트레이딩이 완료되었습니다.`,
+      cashMessage: `선수 트레이드 비용으로 ${compareValuePrice} 캐시가 소모되었습니다.`,
+      myData: {
+        charcterName: myCharacter.name,
+        beforeTradePlayer: {
+          playerName: myPlayer.playerName,
+          characterPlayer: {
+            characterPlayerId: myCharacterPlayer.characterPlayerId,
+            CharacterId: myCharacterPlayer.CharacterId,
+            playerId: myCharacterPlayer.playerId,
+            upgradeLevel: myCharacterPlayer.upgradeLevel,
+          },
+        },
+        afterTradePlayer: {
+          playerName: targetPlayer.playerName,
+          characterPlayer: tradedTargetPlayer,
+        },
+      },
+      targetData: {
+        charcterName: targetCharacter.name,
+        beforeTradePlayer: {
+          playerName: targetPlayer.playerName,
+          characterPlayer: {
+            characterPlayerId: targetCharacterPlayer.characterPlayerId,
+            CharacterId: targetCharacterPlayer.CharacterId,
+            playerId: targetCharacterPlayer.playerId,
+            upgradeLevel: targetCharacterPlayer.upgradeLevel,
+          },
+        },
+        afterTradePlayer: {
+          playerName: myPlayer.playerName,
+          characterPlayer: tradedMyPlayer,
+        },
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/routes/rank-game.router.js
+++ b/src/routes/rank-game.router.js
@@ -4,6 +4,7 @@ import { prisma } from '../utils/prisma/index.js';
 
 const router = express.Router();
 
+// 랭크 풋살 게임 API (JWT 인증)
 router.post('/games/play', authMiddleware, async (req, res, next) => {
   try {
     const { characterId } = req.character;
@@ -24,31 +25,6 @@ router.post('/games/play', authMiddleware, async (req, res, next) => {
 
     let myRankScore = myCharacter.rankScore;
 
-    // 출전 선수 명단 임의의 값 지정
-    /* const testRoster = await prisma.roster.create({
-      data: {
-        CharacterId: characterId,
-        roster1PlayerId: 1,
-        roster1UpgradeLevel: 0,
-        roster2PlayerId: 1,
-        roster2UpgradeLevel: 0,
-        roster3PlayerId: 1,
-        roster3UpgradeLevel: 0,
-      },
-    }); */
-    /* const testRoster2 = await prisma.roster.create({
-      data: {
-        CharacterId: 3,
-        roster1PlayerId: 1,
-        roster1UpgradeLevel: 0,
-        roster2PlayerId: 1,
-        roster2UpgradeLevel: 0,
-        roster3PlayerId: 1,
-        roster3UpgradeLevel: 0,
-      },
-    }); */
-    //console.log(testRoster);
-
     // 모든 캐릭터 조회
     const characters = await prisma.character.findMany({});
 
@@ -58,9 +34,6 @@ router.post('/games/play', authMiddleware, async (req, res, next) => {
     // 각 유저별 랭크 점수 확인
     for (const character of characters) {
       const { characterId } = character;
-
-      const gameScore = character.rankScore;
-      console.log(gameScore);
 
       // 사용자인 경우 제외
       if (myCharacter.characterId === character.characterId) {
@@ -205,14 +178,14 @@ router.post('/games/play', authMiddleware, async (req, res, next) => {
         gameLog.push({
           time: `${currentTime}분`,
           team: `${myCharacter.name} 팀`,
-          goalPlayer : myPlayers[addScorePlayer].playerName
+          goalPlayer: myPlayers[addScorePlayer].playerName,
         });
       } else {
         targetGoal++;
         gameLog.push({
           time: `${currentTime}분`,
           team: `${targetData.name} 팀`,
-          goalPlayer : targetPlayers[addScorePlayer].playerName
+          goalPlayer: targetPlayers[addScorePlayer].playerName,
         });
       }
       currentTime += Math.floor(Math.random() * 45);


### PR DESCRIPTION
### update - 선수 트레이딩 API 기능 구현

- 캐릭터 보유 선수 목록 (타 캐릭터) 조회
- 상대를 지정하여 나의 선수와 상대 선수 트레이드
- ~~금액과 관련된 부분은 구현하지 않고 같은 가치라고 판단~~
- 1대1 교환만 가능하도록 구현
- Request body에 트레이드 금액 제안
    - 내 선수와 상대 선수의 가치가 같으면 금액과 상관없이 제안 수락
    - 가치를 비교하여 트레이드 금액보다 가치가 같거나 작으면 사용자 제안 수락
        - 실제 상대 선수 가치보다 높은 금액으로 트레이드 비용 소모 가능
    - 가치를 비교하여 트레이드 금액보다 가치가 크면 사용자 제안 거절

### API 테스트

- Path Parameter에 트레이드할 캐릭터 보유 선수 입력
- Request body에 트레이드를 원하는 캐릭터, 캐릭터 보유선수 아이디, 트레이드 제안 금액 입력
  - 내 선수의 가치 + 트레이드 제안 금액이 상대 선수의 가치보다 높은 트레이드 제안 금액을 입력

### 인섬니아 성공 (트레이드 수락)

![트레이드 제안 수락](https://github.com/eliotjang/futsal-online-project/assets/37320831/0a7a42e9-678b-4291-a50f-0a7465cc9cb0)

### 인섬니아 성공 (트레이드 거절)

![트레이드 제안 거절](https://github.com/eliotjang/futsal-online-project/assets/37320831/ed7ceb98-8cd1-425f-87e0-70a75be194d5)
