### PR TITLE
69 update 고급 선수 뽑기 api 구현

### DIFF
--- a/src/routes/character.router.js
+++ b/src/routes/character.router.js
@@ -18,6 +18,7 @@ router.get('/character/info', authMiddleware, async (req, res, next) => {
         cash: true,
         releaseCount: true,
         rankScore: true,
+        pityCount: true,
       },
     });
 

--- a/src/routes/draw.router.js
+++ b/src/routes/draw.router.js
@@ -9,6 +9,7 @@ const router = express.Router();
 router.post('/draw', authMiddleware, async (req, res, next) => {
   try {
     const { characterId } = req.character;
+    const drawPrice = 0;
 
     const character = await prisma.character.findFirst({
       //캐릭터 정보 조회
@@ -17,39 +18,39 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
 
     // 선수 방출횟수 확인
     let releaseCount = character.releaseCount;
+    const penaltyPrice = 1000;
 
-    if (character.cash + releaseCount * 1000 < 1000 && releaseCount > 0) {
+    if (character.cash < drawPrice + penaltyPrice && releaseCount > 0) {
       // 선수 방출횟수가 있는 상태에서 캐시 보유 상태 검사
       return res.status(400).json({ Message: '선수 방출 패널티 부여로 인한 보유 캐쉬가 부족합니다.' });
     }
 
-    if (character.cash < 1000) {
+    if (character.cash < drawPrice) {
       //캐시 보유 1000원 이상인지 검사
       return res.status(400).json({ Message: '보유 캐쉬가 부족합니다.' });
     }
 
-    const tier0 = 0.05; //티어에 따른 확률
-    const tier1 = 0.1;
+    const tier0 = 0.01; //티어에 따른 확률
+    const tier1 = 0.04;
     const tier2 = 0.15;
     const tier3 = 0.2;
-    const tier4 = 0.2;
-    const tier5 = 0.3;
+    const tier4 = 0.25;
+    const tier5 = 0.35;
 
-    let rarity = 0;
+    const randomtierList = [tier0, tier1, tier2, tier3, tier4, tier5];
 
     const randomNumRarity = Math.random(); //희귀 등급 뽑기
-    if (randomNumRarity < tier0) {
-      rarity = 0;
-    } else if (randomNumRarity < tier0 + tier1) {
-      rarity = 1;
-    } else if (randomNumRarity < tier0 + tier1 + tier2) {
-      rarity = 2;
-    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3) {
-      rarity = 3;
-    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4) {
-      rarity = 4;
-    } else if (randomNumRarity < tier0 + tier1 + tier2 + tier3 + tier4 + tier5) {
-      rarity = 5;
+
+    let rarity = 0;
+    for (const element in randomtierList) {
+      let currentrandomNum = 0;
+      for (let i = 0; i <= element; i++) {
+        currentrandomNum += randomtierList[i];
+      }
+      if (randomNumRarity < currentrandomNum) {
+        rarity = +element;
+        break;
+      }
     }
 
     const playerList = await prisma.player.findMany({
@@ -74,11 +75,10 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
     });
 
     // 선수 방출 패널티 금액 추가
-    let price = 1000;
+    let price = drawPrice;
     if (releaseCount > 0) {
-      price += 1000;
+      price += penaltyPrice;
     }
-    console.log(releaseCount);
 
     const [characterCashUpdate, playerUpdate] = await prisma.$transaction(
       async (tx) => {
@@ -141,6 +141,240 @@ router.post('/draw', authMiddleware, async (req, res, next) => {
       return res.status(200).json({
         message: '뽑은 선수 데이터입니다.',
         data: radomPlayer,
+      });
+    }
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/draw/rare', authMiddleware, async (req, res, next) => {
+  // 고급 선수 뽑기 API
+  try {
+    const { characterId } = req.character;
+    const { drawCount } = req.body;
+    const drawPrice = 0;
+    let currentPityCount = character.pityCount;
+    let pitySystemStatus = false;
+
+    const character = await prisma.character.findFirst({
+      //캐릭터 정보 조회
+      where: { characterId },
+    });
+
+    // 선수 방출횟수 확인
+    let releaseCount = character.releaseCount;
+    const penaltyPrice = 1000;
+    let decrementReleaseCount = 0;
+
+    if (drawCount < releaseCount) {
+      decrementReleaseCount = drawCount;
+    } else {
+      decrementReleaseCount = releaseCount;
+    }
+
+    if (character.cash < drawPrice * drawCount) {
+      //캐시 보유 (5000 * 뽑기횟수)원 이상인지 검사
+      return res.status(400).json({ Message: '보유 캐쉬가 부족합니다.' });
+    }
+
+    if (character.cash < drawPrice * drawCount + penaltyPrice * decrementReleaseCount && releaseCount > 0) {
+      // 선수 방출횟수가 있는 상태에서 캐시 보유 상태 검사
+      return res.status(400).json({ Message: '선수 방출 패널티 부여로 인한 보유 캐쉬가 부족합니다.' });
+    }
+
+    const tier0 = 0.03; //티어에 따른 확률
+    const tier1 = 0.12;
+    const tier2 = 0.15;
+    const tier3 = 0.2;
+    const tier4 = 0.25;
+    const tier5 = 0.25;
+
+    const randomtierList = [tier0, tier1, tier2, tier3, tier4, tier5];
+
+    const upgradeLevel5 = 0.005; //강화 레벨에 따른 확률
+    const upgradeLevel4 = 0.015;
+    const upgradeLevel3 = 0.035;
+    const upgradeLevel2 = 0.045;
+    const upgradeLevel1 = 0.3;
+    const upgradeLevel0 = 0.6;
+
+    const randomUpgradeLevelList = [
+      upgradeLevel0,
+      upgradeLevel1,
+      upgradeLevel2,
+      upgradeLevel3,
+      upgradeLevel4,
+      upgradeLevel5,
+    ];
+
+    const radomPlayerList = [];
+
+    for (let currentDrawCount = 0; currentDrawCount < drawCount; currentDrawCount++) {
+      const randomNumRarity = Math.random(); //희귀 등급 뽑기
+
+      let rarity = 0;
+      for (const element in randomtierList) {
+        let currentrandomNum = 0;
+        for (let i = 0; i <= element; i++) {
+          currentrandomNum += randomtierList[i];
+        }
+        if (randomNumRarity < currentrandomNum) {
+          rarity = +element;
+          break;
+        }
+      }
+
+      const randomNumUpgradeLevel = Math.random(); //강화레벨 등급 뽑기
+
+      let upgradeLevel = 0;
+      for (const element in randomUpgradeLevelList) {
+        let currentrandomNum = 0;
+        for (let i = 0; i <= element; i++) {
+          currentrandomNum += randomUpgradeLevelList[i];
+        }
+        if (randomNumUpgradeLevel < currentrandomNum) {
+          upgradeLevel = +element;
+          break;
+        }
+      }
+
+      if (rarity == 0) { //좋은것을 뽑앗을 경우 천장 횟수 초기화
+        currentPityCount = 0;
+      }
+
+      if (currentPityCount >= 10) { //천장 10에 도달했을 경우 뽑을 선수 0티어로 설정
+        rarity = 0;
+        currentPityCount -= 10;
+        pitySystemStatus = true;
+      }
+
+      const playerList = await prisma.player.findMany({
+        //뽑기 선수 리스트 조회
+        where: {
+          rarity: rarity,
+          upgradeLevel: upgradeLevel,
+        },
+      });
+
+      const randomNum = Math.floor(Math.random() * playerList.length); //랜덤으로 뽑을 리스트 idex 뽑기
+
+      radomPlayerList.push(playerList[randomNum]); //당첨 선수 정보
+      currentPityCount++
+    }
+
+    const existPlayerList = [];
+    const notExistPlayerList = [];
+    for (const p of radomPlayerList) {
+      const isExistCharacterPlayer = await prisma.characterPlayer.findFirst({
+        //캐릭터 보유 선수중 뽑힌 캐릭터가 있는지
+        where: {
+          CharacterId: character.characterId,
+          playerId: p.playerId,
+          upgradeLevel: p.upgradeLevel,
+        },
+      });
+
+      if (isExistCharacterPlayer) {
+        //존재 한다면 존재하는 선수 리스트 추가
+        if (
+          existPlayerList.some((element) => element.playerId == p.playerId && element.upgradeLevel == p.upgradeLevel)
+        ) {
+          //리스트에 존재한다면 카운트만추가
+          const a = existPlayerList.findIndex((b) => b.playerId == p.playerId && b.upgradeLevel == p.upgradeLevel);
+          existPlayerList[a].playerCount += 1;
+        } else {
+          existPlayerList.push({
+            characterPlayerId: isExistCharacterPlayer.characterPlayerId,
+            CharacterId: character.characterId,
+            playerId: p.playerId,
+            upgradeLevel: p.upgradeLevel,
+            playerCount: 1,
+          });
+        }
+      } else {
+        // 존재하지 않는다면 존재하지 않는 선수 리스트 추가
+        if (
+          notExistPlayerList.some((element) => element.playerId == p.playerId && element.upgradeLevel == p.upgradeLevel)
+        ) {
+          //리스트에 존재한다면 카운트만추가
+          const a = notExistPlayerList.findIndex((b) => b.playerId == p.playerId && b.upgradeLevel == p.upgradeLevel);
+          notExistPlayerList[a].playerCount += 1;
+        } else {
+          notExistPlayerList.push({
+            CharacterId: character.characterId,
+            playerId: p.playerId,
+            upgradeLevel: p.upgradeLevel,
+            playerCount: 1,
+          });
+        }
+      }
+    }
+    console.log(existPlayerList)
+
+    // 선수 방출 패널티 금액 추가
+    let price = drawPrice;
+    if (releaseCount > 0) {
+      price += penaltyPrice * decrementReleaseCount;
+    }
+
+    const [characterCashUpdate, playerUpdate] = await prisma.$transaction(
+      async (tx) => {
+        const characterCashUpdate = await tx.character.update({
+          //캐쉬 차감
+          where: { characterId },
+          data: {
+            cash: { decrement: price },
+          },
+        });
+
+        const playerUpdate = await tx.characterPlayer.createMany({
+          data: [
+            ...notExistPlayerList
+          ],
+        });
+
+        //존재한다면 보유 목록에 선수 카운트 1 더하기
+
+        for (const existPlayer of existPlayerList) {
+
+          const playerUpdate = await tx.characterPlayer.update({
+            where: { characterPlayerId: existPlayer.characterPlayerId },
+            data: {
+              playerCount: { increment: existPlayer.playerCount },
+            },
+          });
+        }
+
+        return [characterCashUpdate, playerUpdate];
+
+      },
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted, // 격리 레벨
+      }
+    );
+
+    if (releaseCount > 0) {
+      // 선수 방출 패널티 횟수 차감, 천장 이후 뽑은 횟수 수정
+      await prisma.character.update({
+        where: { characterId },
+        data: {
+          releaseCount: { decrement: decrementReleaseCount },
+          pityCount: currentPityCount
+        },
+      });
+
+      return res.status(200).json({
+        message: '뽑은 선수 데이터입니다.',
+        addMessage: '선수 방출 패널티로 뽑기에 1000원이 추가 소요되었습니다.',
+        data: radomPlayerList,
+        pitySystem: pitySystemStatus
+      });
+    } else {
+      return res.status(200).json({
+        message: '뽑은 선수 데이터입니다.',
+        data: radomPlayerList,
+        pitySystem: pitySystemStatus
       });
     }
   } catch (err) {


### PR DESCRIPTION
## update - 고급 선수 뽑기 API 구현
1. 일반 뽑기와 고급 선수 뽑기 차이를 주기 위하여 높은 티어 뽑을 확률 일반은 낮게 고급은 높게 수정 

2. 고급 뽑기에서 강화된 선수 등장하도록 선수 뽑기 로직과 비슷하게 구현

3. 연속 뽑기가 가능하도록 for문 이용하여서 여러번 뽑은 다음 배열에 저장

4. for문으로 뽑는 도중 지금까지 뽑은 횟수(pityCount)가 10번째 일 경우 0티어 뽑히고 뽑은 횟수(pityCount)가 0으로 초기화 되도록 구현

5. 하지만 for문 도중 0티어가 뽑힐경우 뽑은 횟수(pityCount)가 0으로 초기화

6. 천장 시스템으로 0티어를 뽑을 경우 pitySystem을 true로 출력한다.

7. 뽑은 선수가 보유 선수 목록에 없을 경우 createMany로 배열에 있는 선수 저장

8. 뽑은 선수가 보유 선수 목록에 있을경우 for문으로 update로 playerCount 1추가
 
###인섬니아
![image](https://github.com/eliotjang/futsal-online-project/assets/112794665/0d06a571-3959-4fe5-9b5b-f3e3b5df35f3)



## fix - 캐릭터 정보조회 character 모델 변경에 따른 수정
character모델 pityCount 컬럼이 추가됨에 따라서 
캐릭터 조회시 pityCount 항목 추가

###인섬니아
![image](https://github.com/eliotjang/futsal-online-project/assets/112794665/1ceed3b0-2728-4dfd-9adb-d8ee3cdc3144)
