### PR TITLE
66 fix 변경된 데이터베이스에 따른 이적 시장 api 로직 변경

### DIFF
--- a/src/routes/transfer.router.js
+++ b/src/routes/transfer.router.js
@@ -59,18 +59,6 @@ router.post('/transfer', authMiddleware, async (req, res, next) => {
             upgradeLevel,
             offerCash,
           },
-          select: {
-            Character: {
-              select: {
-                characterId: true,
-                name: true,
-              },
-            },
-            playerId: true,
-            playerName: targetPlayer.playerName,
-            upgradeLevel: true,
-            offerCash: true,
-          },
         });
 
         return [transferMarket];
@@ -80,7 +68,19 @@ router.post('/transfer', authMiddleware, async (req, res, next) => {
       }
     );
 
-    return res.status(201).json({ message: '이적 시장 등록이 완료되었습니다.', data: transferMarket });
+    const character = await prisma.character.findFirst({
+      where: {characterId}
+    })
+
+    const data = {
+      characterId,
+      name: character.name,
+      playerId,
+      upgradeLevel,
+      offerCash,
+    }
+
+    return res.status(201).json({ message: '이적 시장 등록이 완료되었습니다.', data });
   } catch (err) {
     next(err);
   }
@@ -89,17 +89,19 @@ router.post('/transfer', authMiddleware, async (req, res, next) => {
 // 이적 시장 조회 API
 router.get('/transfer', authMiddleware, async (req, res, next) => {
   try {
-    const transferMarket = await prisma.transferMarket.findMany({
-      where: { status: 'continue' },
+    const possibleTransferMarket = await prisma.transferMarket.findMany({
+      where: { transferStatus: 'false' },
       select: {
-        transferMarketId: true,
-        sellCharacterId: true,
-        sellCharacterName: true,
-        sellCharacterPlayerId: true,
-        sellCharacterPlayerName: true,
-        sellCharacterPlayerUpgradeLevel: true,
-        sellCash: true,
-        status: true,
+        Character: {
+          select: {
+            characterId: true,
+            name: true,
+          },
+        },
+        playerId: true,
+        playerName: targetPlayer.playerName,
+        upgradeLevel: true,
+        offerCash: true,
       },
     });
 

--- a/src/routes/transfer.router.js
+++ b/src/routes/transfer.router.js
@@ -54,15 +54,15 @@ router.post('/transfer', authMiddleware, async (req, res, next) => {
 
         const transferMarket = await tx.transferMarket.create({
           data: {
-            characterId,
+            CharacterId: characterId,
             playerId,
             upgradeLevel,
             offerCash,
           },
           select: {
-            characterId: true,
             Character: {
               select: {
+                characterId: true,
                 name: true,
               },
             },


### PR DESCRIPTION
### 이적 시장 조회 API 수정
- 이적 상태에 따라 2개의 배열로 조회
- 데이터베이스에 따른 로직 변경
![image](https://github.com/eliotjang/futsal-online-project/assets/166112137/ea306441-2406-469f-b1dd-5c40f370b8de)
### 이적 시장 등록 API 수정
- 개수가 1개인 캐릭터 보유선수 이적 시장 등록 시, 캐릭터 보유선수 테이블 삭제
- 데이터베이스에 따른 로직 변경
![image](https://github.com/eliotjang/futsal-online-project/assets/166112137/5a4e26f5-cb1d-46c9-90cb-a9553b1d0a65)
### 이적 시장 구매 API 수정
- 데이터베이스에 따른 로직 변경
![image](https://github.com/eliotjang/futsal-online-project/assets/166112137/391357ea-dc14-4a6d-ba02-4ee3dfd4883e)
### 이적 시장 등록 취소 API 수정
- 캐릭터 보유선수가 없으면 테이블 생성
- 데이터베이스에 따른 로직 변경
![image](https://github.com/eliotjang/futsal-online-project/assets/166112137/b9e3edd6-fc43-41da-9412-5e0ea2ba69dc)
