### PR TITLE
refactor - HTTP 상태 코드 및 메세지 API 명세와 동일하게 수정

### DIFF
--- a/src/routes/roster.router.js
+++ b/src/routes/roster.router.js
@@ -53,7 +53,7 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
       if (requestRosterPlayers[0]) {
         for (const playerId of requestRosterPlayers[0]) {
           if (characterPlayer.playerId === playerId) {
-            return res.status(409).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
+            return res.status(400).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
           }
         }
       }

--- a/src/routes/roster.router.js
+++ b/src/routes/roster.router.js
@@ -15,11 +15,11 @@ const characterIdSchema = Joi.object({
 // 출전 선수 명단 유효성 검사
 const rosterSchema = Joi.object({
   roster1PlayerId: Joi.number().integer().required(),
-  roster1UpgradeLevel: Joi.number().integer().required(),
+  roster1UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
   roster2PlayerId: Joi.number().integer().required(),
-  roster2UpgradeLevel: Joi.number().integer().required(),
+  roster2UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
   roster3PlayerId: Joi.number().integer().required(),
-  roster3UpgradeLevel: Joi.number().integer().required(),
+  roster3UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
 });
 
 // 출전 선수 명단 구성 API (JWT 인증)
@@ -92,7 +92,7 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
         roster2PlayerId: roster.roster2PlayerId,
         roster2UpgradeLevel: roster.roster2UpgradeLevel,
         roster3PlayerId: roster.roster3PlayerId,
-        roster1UpgradeLevel: roster.roster1UpgradeLevel,
+        roster3UpgradeLevel: roster.roster3UpgradeLevel,
       },
     });
   } catch (error) {
@@ -209,7 +209,7 @@ router.get('/roster/:characterId', async (req, res, next) => {
       players.push(player);
     }
 
-    return res.status(200).json({ data: players });
+    return res.status(200).json({ message: `${character.name} 캐릭터의 출전 선수 명단입니다.`, data: players });
   } catch (error) {
     next(error);
   }

--- a/src/routes/roster.router.js
+++ b/src/routes/roster.router.js
@@ -14,24 +14,20 @@ const characterIdSchema = Joi.object({
 
 // 출전 선수 명단 유효성 검사
 const rosterSchema = Joi.object({
-  roster1PlayerId: Joi.number().integer().required(),
-  roster1UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
-  roster2PlayerId: Joi.number().integer().required(),
-  roster2UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
-  roster3PlayerId: Joi.number().integer().required(),
-  roster3UpgradeLevel: Joi.number().integer().min(0).max(5).required(),
+  characterPlayerId1: Joi.number().integer().required(),
+  characterPlayerId2: Joi.number().integer().required(),
+  characterPlayerId3: Joi.number().integer().required(),
 });
 
 // 출전 선수 명단 구성 API (JWT 인증)
 router.post('/roster', authMiddleware, async (req, res, next) => {
   try {
     const validaion = await rosterSchema.validateAsync(req.body);
-    const { roster1PlayerId, roster2PlayerId, roster3PlayerId } = validaion;
-
+    const { characterPlayerId1, characterPlayerId2, characterPlayerId3 } = validaion;
     if (
-      roster1PlayerId === roster2PlayerId ||
-      roster1PlayerId === roster3PlayerId ||
-      roster2PlayerId === roster3PlayerId
+      characterPlayerId1 === characterPlayerId2 ||
+      characterPlayerId1 === characterPlayerId3 ||
+      characterPlayerId2 === characterPlayerId3
     ) {
       return res.status(400).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
     }
@@ -42,19 +38,26 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
       include: { CharacterPlayer: true, Roster: true },
     });
 
-    const requestRosterPlayers = Futsal.rosterToRosterPlayers(validaion);
+    const requestRosterPlayerIds = [characterPlayerId1, characterPlayerId2, characterPlayerId3];
+    const requestRosterPlayers = [];
 
-    for (const [playerId, upgradeLevel] of requestRosterPlayers) {
+    for (const characterPlayerId of requestRosterPlayerIds) {
       const characterPlayer = character.CharacterPlayer.find((characterPlayer) => {
-        return (
-          characterPlayer.playerId === playerId &&
-          characterPlayer.upgradeLevel === upgradeLevel &&
-          characterPlayer.playerCount > 0
-        );
+        return characterPlayer.characterPlayerId === characterPlayerId;
       });
+
       if (!characterPlayer) {
         return res.status(400).json({ errorMessage: '선수 아이디가 유효하지 않습니다.' });
       }
+
+      if (requestRosterPlayers[0]) {
+        for (const playerId of requestRosterPlayers[0]) {
+          if (characterPlayer.playerId === playerId) {
+            return res.status(409).json({ errorMessage: '선수 아이디가 중복되었습니다.' });
+          }
+        }
+      }
+      requestRosterPlayers.push([characterPlayer.playerId, characterPlayer.upgradeLevel]);
     }
 
     // 출전 선수 명단 생성
@@ -84,16 +87,24 @@ router.post('/roster', authMiddleware, async (req, res, next) => {
       }
     );
 
+    const players = [];
+    const rosterPlayers = Futsal.rosterToRosterPlayers(roster);
+
+    for (const [rosterPlayerId, rosterUpgradeLevel] of rosterPlayers) {
+      const player = await prisma.player.findUnique({
+        where: { playerId_upgradeLevel: { playerId: rosterPlayerId, upgradeLevel: rosterUpgradeLevel } },
+      });
+
+      if (!player) {
+        return res.status(404).json({ errorMessage: '요청한 선수를 찾을 수 없습니다.' });
+      }
+
+      players.push(player);
+    }
+
     return res.status(201).json({
       message: '출전 선수 명단입니다.',
-      data: {
-        roster1PlayerId: roster.roster1PlayerId,
-        roster1UpgradeLevel: roster.roster1UpgradeLevel,
-        roster2PlayerId: roster.roster2PlayerId,
-        roster2UpgradeLevel: roster.roster2UpgradeLevel,
-        roster3PlayerId: roster.roster3PlayerId,
-        roster3UpgradeLevel: roster.roster3UpgradeLevel,
-      },
+      data: players,
     });
   } catch (error) {
     next(error);

--- a/src/routes/upgrade.router.js
+++ b/src/routes/upgrade.router.js
@@ -47,7 +47,7 @@ router.post('/upgrade/:characterPlayerId', authMiddleware, async (req, res, next
       return characterPlayer.characterPlayerId === targetCharacterPlayerId;
     });
 
-    if (!targetCharacterPlayer || targetCharacterPlayer.playerCount < 1) {
+    if (!targetCharacterPlayer) {
       return res.status(400).json({ errorMessage: '강화할 선수가 현재 보유한 선수가 아닙니다.' });
     }
     if (targetCharacterPlayer.upgradeLevel > 4) {
@@ -61,12 +61,12 @@ router.post('/upgrade/:characterPlayerId', authMiddleware, async (req, res, next
       return characterPlayer.characterPlayerId === materialCharacterPlayerId;
     });
 
-    if (
-      !materialCharacterPlayer ||
-      materialCharacterPlayer.playerCount < 1 ||
-      (materialCharacterPlayer === targetCharacterPlayer && materialCharacterPlayer.playerCount < 2)
-    ) {
+    if (!materialCharacterPlayer) {
       return res.status(400).json({ errorMessage: '강화 재료 선수가 현재 보유한 선수가 아닙니다.' });
+    }
+
+    if (materialCharacterPlayer === targetCharacterPlayer && materialCharacterPlayer.playerCount < 2) {
+      return res.status(400).json({ errorMessage: '강화 재료 선수의 수량이 부족합니다.' });
     }
 
     if (targetCharacterPlayer.playerId !== materialCharacterPlayer.playerId) {


### PR DESCRIPTION
## refactor - HTTP 상태 코드 및 메세지 API 명세와 동일하게 수정
### 주요 내용
- 출전 선수 관련 API 수정 (`"src/routes/roster.router.js"`)
  - 상태 코드 및 메세지 수정
  - 출전 선수 조회(JWT 미인증) path parameter 유효성 검사 추가
  - 출전 선수 구성 req , res 값 변경

- 선수 강화 API 수정 (`"src/routes/upgrade.router.js"`)
  - 상태 코드 및 메세지 수정

### 상세
- 출전 선수 관련 API 수정 (`"src/routes/roster.router.js"`)
  - 상태 코드 및 메세지 수정
    - 해당 캐릭터를 찾을 수 없는 경우 : HTTP 코드 `400` -> `404` 변경 및 메세지 변경
    - 해당 캐릭터의 출전 명단이 없는 경우 : 메세지 변경
    - 출전 선수 조회(JWT 미인증) 메세지 추가
      `message: ${character.name} 캐릭터의 출전 선수 명단입니다.`
    
  - 출전 선수 조회(JWT 미인증) path parameter 유효성 검사 추가
    `const characterIdSchema = Joi.object({ characterId: Joi.number().integer().required(), });`

  - 출전 선수 구성 req , res 값 변경
    - 출전 선수 구성 req 입력 값 변경
      - 선수(1 ~ 3) 아이디, 강화 단계 입력 -> 보유 선수(1 ~ 3) 아이디 입력
    - 출전 선수 구성 res 반환 값 변경
      - 선수(1 ~ 3) 아이디, 강화 단계 반환 -> 출전 선수의 선수 데이터 명단 반환
      
     ![image](https://github.com/eliotjang/futsal-online-project/assets/84895591/9b3c0b54-bc21-4560-bb95-06207ab66e7d)

- 선수 강화 API 수정 (`"src/routes/upgrade.router.js"`)
  - 상태 코드 및 메세지 수정
    - 강화할 선수와 강화 재료 선수가 동일하며 해당 선수의 `player_count < 2`일 때, 메세지 추가
      `errorMessage: '강화 재료 선수의 수량이 부족합니다.'`